### PR TITLE
Using the same `js-md5` from `web-components`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "platform.js": "platform#^1.3.4",
-    "js-md5": "^2.10.0"
+    "js-md5": "md5#^0.7.2"
   },
   "devDependencies": {
     "web-components": "git@github.com:KanoComputing/web-components.git#master",
@@ -32,6 +32,6 @@
   "resolutions": {
     "polymer": "^1.9.0",
     "webcomponentsjs": "^0.7.24",
-    "js-md5": "^2.10.0"
+    "js-md5": "^0.7.2"
   }
 }

--- a/kwc-tracking.html
+++ b/kwc-tracking.html
@@ -1,4 +1,4 @@
-<script src="../js-md5/js/md5.min.js"></script>
+<script src="../js-md5/build/md5.min.js"></script>
 <script src="../platform.js/platform.js"></script>
 
 <script>


### PR DESCRIPTION
# The problem

There are two `js-md5` libraries, one being used by `web-components` and the other used by `kwc-behaviours` (which should be called `behaviors` since that is the "polymer nomenclature").

The API is pretty much the same but the file structure is not: `js/js-md5.min.js` and `build/js-md5.min.js`

When building `kano2-app`, Jenkins throws the following complain:
```
[rpi] ERROR finding /tmp/kano2-app-workdir/kano2-app/bower_components/js-md5/build/md5.min.js
```

And fails the build making everyone's life a bit worse.

# The solution

Use the same version of `js-md5` being used by `web-components` so hopefully Jenkins can build and we can have a good weekend.

# The packages

- https://github.com/blueimp/JavaScript-MD5
- https://github.com/emn178/js-md5 (<-- Using this one)