### PR TITLE
Queue tracking error events if fired before behaviour is initialized

### DIFF
--- a/kwc-tracking.html
+++ b/kwc-tracking.html
@@ -486,8 +486,9 @@
              * @param {Object} payload
              */
             function _trackError (payload) {
-                payload.os = os.name;
-                payload.os_version = os.version;
+                if (!sessionStarted) {
+                    return preInitEvents.push(payload);
+                }
                 _queueEvent(payload);
             }
             /**


### PR DESCRIPTION
Ensures that all tracking events have the data they need in order to be accepted by the API.